### PR TITLE
Stabilize Joystick Assignment

### DIFF
--- a/src/houston_pkg/launch/joystick_launch.launch.py
+++ b/src/houston_pkg/launch/joystick_launch.launch.py
@@ -11,8 +11,8 @@ def generate_launch_description():
                 ('/joy', '/joy_thruster')
             ],
             parameters=[{
-                'dev': '/dev/input/js0',
-                'device_id': 1
+                'dev': '/dev/input/by-id/usb-PowerA_Xbox_Series_X_EnWired_Controller_Blue_inline_0000010A899E80B3-joystick',
+                # 'device_id': 0
             }]
 
         ),
@@ -24,8 +24,8 @@ def generate_launch_description():
                 ('/joy', '/joy_arm')
             ],
             parameters=[{
-                'dev': '/dev/input/js1',
-                'device_id': 0
+                'dev': '/dev/input/by-id/usb-©Microsoft_Corporation_Controller_86231B39-joystick',
+                # 'device_id': 1
             }]
         ),
     ])


### PR DESCRIPTION
Used USB ID path to distinguish between joysticks. 
The paths may need to be changed based on the device the joysticks are plugged in, but this is a one-time thing. 